### PR TITLE
Add: Add a basic error handling

### DIFF
--- a/qr-note/src/main.rs
+++ b/qr-note/src/main.rs
@@ -1,8 +1,8 @@
-use qrcode::QrCode;
 use image::Rgb;
-use slint::SharedPixelBuffer;
-use slint::Rgb8Pixel;
+use qrcode::QrCode;
 use slint::Image;
+use slint::Rgb8Pixel;
+use slint::SharedPixelBuffer;
 slint::include_modules!();
 
 fn main() -> Result<(), slint::PlatformError> {
@@ -11,14 +11,20 @@ fn main() -> Result<(), slint::PlatformError> {
     let ui_handle = ui.as_weak();
     ui.on_text_is_edited(move || {
         let ui = ui_handle.unwrap();
-        let code = QrCode::new(ui.get_thetext()).unwrap();
-        let image = code.render::<Rgb<u8>>().build();
-        let pixel_buffer = SharedPixelBuffer::<Rgb8Pixel>::clone_from_slice(
-            image.as_raw(),
-            image.width(),
-            image.height());
-        ui.set_qrnote(Image::from_rgb8(pixel_buffer));
+        match QrCode::new(ui.get_thetext()) {
+            Ok(code) => {
+                let image = code.render::<Rgb<u8>>().build();
+                let pixel_buffer = SharedPixelBuffer::<Rgb8Pixel>::clone_from_slice(
+                    image.as_raw(),
+                    image.width(),
+                    image.height(),
+                );
+                ui.set_errormsg("Ok".into());
+                ui.set_qrnote(Image::from_rgb8(pixel_buffer));
+            }
+            Err(e) => ui.set_errormsg(e.to_string().into()),
+        }
     });
- 
+
     ui.run()
 }

--- a/qr-note/ui/appwindow.slint
+++ b/qr-note/ui/appwindow.slint
@@ -1,9 +1,10 @@
 import { Button, VerticalBox } from "std-widgets.slint";
-import { HorizontalBox, TextEdit } from "std-widgets.slint";
+import { HorizontalBox, TextEdit, LineEdit } from "std-widgets.slint";
 
 export component AppWindow inherits Window {
     in-out property<image> qrnote: @image-url("icons/QRNote.png");
     out property<string> thetext: "";
+    in property<string> errormsg: "Ok";
     callback text-is-edited();
     VerticalBox {
         TextEdit {
@@ -14,6 +15,12 @@ export component AppWindow inherits Window {
                 thetext = text;
                 root.text-is-edited();
             }
+        }
+        LineEdit {
+            text: errormsg;
+            width: 300px;
+            read-only: true;
+            horizontal-alignment: center;
         }
         Image {
             source : qrnote;


### PR DESCRIPTION
Very primitive error handlnig so your app won't crash anymore when input data is too long or when any other QRCode generation error occurs (Invalid chars for example)